### PR TITLE
Update `linked_arms` to make use of `REDCapR::redcap_arm_export`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -46,9 +46,10 @@ link_arms <- function(
   # Next map through all possible arms by identifying unique ones in db_data_long
   # after it has helper variables added from `add_partial_keys()`
   db_event_instruments <- tibble() # Define empty tibble
-  arms <- db_data_long %>% pull(redcap_arm) %>% unique() # Define arms
 
-  db_event_instruments <- map(arms, ~redcap_event_instruments(
+  arms <- redcap_arm_export(redcap_uri, token, verbose = FALSE)$data
+
+  db_event_instruments <- map(arms$arm_number, ~redcap_event_instruments(
     redcap_uri = redcap_uri,
     token = token, arms = .x,
     verbose = FALSE


### PR DESCRIPTION
# Description
This PR contains a very small bug fix by changing how `link_arms` identifies REDCap arms using the new `REDCapR::redcap_arm_export()` function (new as of `v1.1.0`).

# Proposed Changes 
List changes below in bullet format:

- Update how REDCap arms are defined to rely on export instead of database identification

**Screenshots**
NA

### Issue Addressed
**Closes #17**

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [x] New/revised functions have associated tests
- [x] New/revised functions use appropriate naming conventions
- [x] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [x] I checked that new files follow naming conventions and are in the right place
- [x] I checked that documentation is complete, clear, and without typos
- [x] I added/edited comments to explain "why" not "how"
- [x] I checked that all new variable and function names follow naming conventions
- [x] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [x] I checked that new tests address important edge cases