### PR TITLE
Include checkbox field labels in metadata

### DIFF
--- a/tests/testthat/test-read_redcap_tidy.R
+++ b/tests/testthat/test-read_redcap_tidy.R
@@ -245,9 +245,9 @@ test_that("errors when non-existent form is supplied with existing forms", {
 test_that("get_fields_to_drop handles checkboxes", {
   # Example metadata
   test_meta <- tibble::tribble(
-    ~field_name,   ~form_name, ~field_type, ~select_choices_or_calculations,
-    "record_id",   "my_form",  "text",      NA_character_,
-    "my_checkbox", "my_form",  "checkbox",  "1, 1 | -99, Unknown"
+    ~field_name,   ~form_name, ~field_type, ~select_choices_or_calculations, ~field_label,
+    "record_id",   "my_form",  "text",      NA_character_, NA_character_,
+    "my_checkbox", "my_form",  "checkbox",  "1, 1 | -99, Unknown", NA_character_
   )
 
   res <- get_fields_to_drop(test_meta, "my_form")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -112,3 +112,63 @@ test_that("link_arms works", {
   expect_equal(n_unique_arms, 2)
 
 })
+
+test_that("update_field_names works", {
+  test_meta <- tibble::tribble(
+    ~field_name,   ~form_name, ~field_type, ~field_label, ~select_choices_or_calculations,
+    "record_id",   NA_character_,  "text", NA_character_, NA_character_,
+    "my_checkbox", "my_form",  "checkbox", "Field Label", "1, 1 | -99, Unknown {embedded logic}",
+    "checkbox_no_label", "my_form",  "checkbox", NA_character_, "1, 1"
+  )
+
+  out <- update_field_names(test_meta)
+
+  # Check cols are present and correctly ordered
+  expected_cols <- c(
+    "field_name", "form_name", "field_type", "field_label",
+    "select_choices_or_calculations", "field_name_updated"
+  )
+
+  expect_equal(colnames(out), expected_cols)
+
+  # Check field_name_updated was created correctly
+  field_name_updated <- out$field_name_updated[-1] # drop record_id row
+
+  expect_equal(
+    field_name_updated,
+    c("my_checkbox___1", "my_checkbox___-99", "checkbox_no_label___1")
+  )
+
+  # Check field_label was correctly updated in place
+
+  ## Checkbox labs appended in parentheses
+  ## field embedding logic stripped
+  ## Missing field labels converted to NA
+  field_label <- out$field_label[-1] # drop record_id row
+
+  expect_equal(
+    field_label,
+    c("Field Label (1)", "Field Label (Unknown)", "NA (1)")
+  )
+
+})
+
+test_that("update_field_names handles metadata without checkbox fields", {
+  test_meta <- tibble::tribble(
+    ~field_name,   ~form_name, ~field_type, ~field_label, ~select_choices_or_calculations,
+    "record_id",   NA_character_,  "text", NA_character_, NA_character_,
+    "my_radio",   NA_character_,  "radio", "xyz", "abc"
+  )
+
+  out <- update_field_names(test_meta)
+
+  # field_name_update is the same as field_name
+
+  expect_equal(out$field_name, out$field_name_updated)
+
+  # field_label is unchanged
+
+  expect_equal(out$field_label, test_meta$field_label)
+
+
+})


### PR DESCRIPTION
# Description
This PR updates our processing of the REDCap metadata to include checkbox option labels in the `field_label` column for each checkbox option row. The output differs slightly from what I described in #70:

Input:
|field_name|field_label|select_choices_or_calculations|
|----------------------|----------------------|-------------------------|
crs_anti_tcell_therapy_types | Anti-T Cell therapy given: | cyclophosphamide, Cyclophosphamide \| atg, ATG \| other, Other {crs_anti_tcell_therapy_types_specify}|

Output:
|field_name|field_label|updated_field_name|
|----------------------|----------------------|-------------------------|
crs_anti_tcell_therapy_types | Anti-T Cell therapy given: (Cyclophosphamide) | crs_anti_tcell_therapy_types___cyclophosphamide |
crs_anti_tcell_therapy_types | Anti-T Cell therapy given: (ATG) | crs_anti_tcell_therapy_types___atg |
crs_anti_tcell_therapy_types | Anti-T Cell therapy given: (Other) | crs_anti_tcell_therapy_types___other |

Two questions:
1. Not sure I like the carried over ":" in the middle of the field label but not sure how much additional formatting we should do by default. Should we do more? Currently we're just stripping field embedding + whitespace from the checkbox labels.
2. I had to make a decision on what happens if the checkbox field itself doesn't have a label. The current behavior is to print an explicit `"NA"` in the place of the field label before the checkbox option label. So:

|field_name|field_label|select_choices_or_calculations|
|---------|---------|----------|
my_field |  `NA` | 1, Option Label |

becomes

|field_name|field_label|updated_field_name|
|-------|-----------|--------------|
my_field |  NA (Option Label) |  my_field___1 |

Are there alternative suggestions?

# Proposed Changes

- Alter `update_field_names()` to edit `db_metadata$field_label` in place by appending checkbox option labels after the field label
    - This involved moving the `parse_labels()` call from `checkbox_appender()` into the body of `update_field_names()` so we can use both the labels and raw values. At that point enough of `checkbox_appender()` was whittled away that I just removed it.

### Issue Addressed
Addresses #70 (not closing until merged to main with #65)

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [x] New/revised functions have associated tests
- [x] New tests that make API calls use `httptest::with_mock_api` and any new mocks were added to `tests/testthat/fixtures/create_httptest_mocks.R`
- [x] New/revised functions use appropriate naming conventions
- [x] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases
