### PR TITLE
Repair malformed REDCap choice strings during label parsing

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -201,6 +201,19 @@ parse_labels <- function(string, return_vector = FALSE, return_stripped_text_fla
     )
   }
 
+  repaired <- repair_redcap_choice_string(string)
+  string <- repaired$string
+
+  if (isTRUE(repaired$repaired)) {
+    cli_warn(
+      c(
+        "!" = "Applied conservative formatting repairs to a `select_choices_or_calculations` field before parsing.",
+        "i" = "This usually indicates malformed REDCap metadata such as repeated `|` separators or missing spacing after a separator."
+      ),
+      class = c("choice_string_repaired", "REDCapTidieR_cond")
+    )
+  }
+
   out <- string %>%
     strsplit("\\|") %>% # Split by "|"
     lapply(trimws) # Trim trailing and leading whitespace in list elements
@@ -272,6 +285,24 @@ parse_labels <- function(string, return_vector = FALSE, return_stripped_text_fla
   }
 
   out
+}
+
+repair_redcap_choice_string <- function(string) {
+  if (is.na(string) || !nzchar(trimws(string))) {
+    return(list(string = string, repaired = FALSE))
+  }
+
+  original <- string
+  repaired <- string
+
+  repaired <- gsub("\\|\\s*([0-9]+)\\s*,", "| \\1,", repaired, perl = TRUE)
+  repaired <- gsub("\\|\\s*\\|+", " | ", repaired, perl = TRUE)
+  repaired <- trimws(repaired)
+
+  list(
+    string = repaired,
+    repaired = !identical(original, repaired)
+  )
 }
 
 #' @title

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -121,6 +121,15 @@ test_that("parse_labels works", {
 
   invalid_string_1 <- "raw, label | that has | pipes but no other | commas"
   invalid_string_2 <- "raw, la|bel with pipe"
+  repairable_string_1 <- "803, Apple | 804, Banana | 805, Cherry |806, Dragon Fruit| | 807, Elderberry"
+  repairable_output_1 <- tibble::tribble(
+    ~raw, ~label,
+    "803", "Apple",
+    "804", "Banana",
+    "805", "Cherry",
+    "806", "Dragon Fruit",
+    "807", "Elderberry"
+  )
 
   warning_string_1 <- NA_character_
 
@@ -136,6 +145,14 @@ test_that("parse_labels works", {
   expect_error(
     parse_labels(invalid_string_2),
     class = "label_parse_error"
+  )
+  expect_warning(
+    parse_labels(repairable_string_1),
+    class = "choice_string_repaired"
+  )
+  expect_equal(
+    suppressWarnings(parse_labels(repairable_string_1), classes = "choice_string_repaired"),
+    repairable_output_1
   )
   expect_warning(
     parse_labels(warning_string_1),


### PR DESCRIPTION
# Description
Adds a conservative repair step before `parse_labels()` processes `select_choices_or_calculations` values from REDCap metadata.

The change is intended to improve resilience when metadata contain minor formatting defects that are still recoverable, such as repeated pipe separators or missing spacing after a separator before a numeric code. The repair step is intentionally narrow and preserves existing parser errors for strings that remain ambiguous or invalid after repair.

# Proposed Changes 

- Add a small preprocessing helper that repairs minor recoverable formatting defects in REDCap choice strings before parsing
- Update parse_labels() to use the repaired string while preserving its existing return contract for downstream helpers
- Add a regression test using placeholder values to confirm that repairable malformed strings parse successfully
- Preserve current error behavior for malformed strings that are not safely repairable
- Emit a warning when conservative formatting repair is applied before parsing

**Screenshots**
N/A

### Issue Addressed
`read_redcap()` would fail due to a missing space and an extra "|" delimiter in `select_choices_or_calculations` values that caused `parse_labels()` to fail. 

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [x] New/revised functions have associated tests
- [ ] New/revised functions that update downstream outputs have associated static testing files (`.RDS`) updated under `inst/testdata/create_test_data.R`
- [x] New/revised functions use appropriate naming conventions
- [x] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [ ] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] The appropriate reviewer is assigned to the PR
- [ ] The appropriate developers are assigned to the PR
- [ ] Pre-release package version incremented using `usethis::use_version()`

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214136483626380